### PR TITLE
fix Injectors not working due to error on use

### DIFF
--- a/1.4/Defs/HediffDefs/ArchotechPlus_Hediffs_BodyParts_Archotech.xml
+++ b/1.4/Defs/HediffDefs/ArchotechPlus_Hediffs_BodyParts_Archotech.xml
@@ -46,9 +46,7 @@ See the link below for In-Game Effects:</description>
         <bodyPart>Sternum</bodyPart>
         <canUpgrade>true</canUpgrade>
       </li>
-      <li Class="CompProperties_UseEffect">
-        <compClass>CompUseEffect_DestroySelf</compClass>
-      </li>
+      <li Class="CompProperties_UseEffectDestroySelf" />
     </comps>
   </ThingDef>
   <HediffDef ParentName="ImplantHediffBase">
@@ -115,9 +113,7 @@ See the link below for In-Game Effects:</description>
         <bodyPart>Torso</bodyPart>
         <canUpgrade>true</canUpgrade>
       </li>
-      <li Class="CompProperties_UseEffect">
-        <compClass>CompUseEffect_DestroySelf</compClass>
-      </li>
+      <li Class="CompProperties_UseEffectDestroySelf" />
     </comps>
   </ThingDef>
   <HediffDef ParentName="ImplantHediffBase">
@@ -203,9 +199,7 @@ See the link below for In-Game Effects:</description>
         <bodyPart>Brain</bodyPart>
         <canUpgrade>true</canUpgrade>
       </li>
-      <li Class="CompProperties_UseEffect">
-        <compClass>CompUseEffect_DestroySelf</compClass>
-      </li>
+      <li Class="CompProperties_UseEffectDestroySelf" />
     </comps>
   </ThingDef>
   <HediffDef ParentName="ImplantHediffBase">
@@ -278,9 +272,7 @@ See the link below for In-Game Effects:</description>
         <bodyPart>Liver</bodyPart>
         <canUpgrade>true</canUpgrade>
       </li>
-      <li Class="CompProperties_UseEffect">
-        <compClass>CompUseEffect_DestroySelf</compClass>
-      </li>
+      <li Class="CompProperties_UseEffectDestroySelf" />
     </comps>
   </ThingDef>
   <HediffDef ParentName="ImplantHediffBase">


### PR DESCRIPTION
This fixes the Injectors/implants to fail installing on 1.4 with the error message 
```
JobDriver threw exception in toil Use's initAction for pawn Foobar driver=JobDriver_UseItem (toilIndex=2) driver.job=(UseItem (Job_1426443) A=Thing_ArchotechBioadapter977863)
System.InvalidCastException: Specified cast is not valid.
```

The issue is simply that `<compClass>CompUseEffect_DestroySelf</compClass>` is no longer defined and instead has been replaced with `<li Class="CompProperties_UseEffectDestroySelf" />`.