### PR TITLE
Add levelIsQuantity attribute to archotech hediffs

### DIFF
--- a/1.6/Defs/HediffDefs/ArchotechPlus_Hediffs_BodyParts_Archotech.xml
+++ b/1.6/Defs/HediffDefs/ArchotechPlus_Hediffs_BodyParts_Archotech.xml
@@ -55,6 +55,7 @@
     <initialSeverity>1</initialSeverity>
     <minSeverity>0</minSeverity>
     <maxSeverity>3</maxSeverity>
+    <levelIsQuantity>true</levelIsQuantity>
     <stages>
       <li>
         <minSeverity>1</minSeverity>
@@ -104,6 +105,7 @@
     <initialSeverity>1</initialSeverity>
     <minSeverity>0</minSeverity>
     <maxSeverity>3</maxSeverity>
+    <levelIsQuantity>true</levelIsQuantity>
     <stages>
       <li>
         <minSeverity>1</minSeverity>
@@ -174,6 +176,7 @@
     <initialSeverity>1</initialSeverity>
     <minSeverity>0</minSeverity>
     <maxSeverity>2</maxSeverity>
+    <levelIsQuantity>true</levelIsQuantity>
     <stages>
       <li>
         <minSeverity>1</minSeverity>
@@ -235,6 +238,7 @@
     <initialSeverity>1</initialSeverity>
     <minSeverity>0</minSeverity>
     <maxSeverity>2</maxSeverity>
+    <levelIsQuantity>true</levelIsQuantity>
     <stages>
       <li>
         <minSeverity>1</minSeverity>


### PR DESCRIPTION
Fixed a visual issue that was bugging me out, the "(LevelNum)" being displayed instead of actual implant level in the health tab. This was done by adding 'levelIsQuantity' attribute to the hediffs. 
Tested the change on my end, worked as intended.